### PR TITLE
add mov-cli to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ features.
   tmux!
 - [yazi](https://github.com/sxyazi/yazi) - works if you run it as
   `TERM="xterm-kitty" yazi`.
+- [mov-cli](https://github.com/mov-cli/mov-cli) - I had to explicitely set
+  `TERM="xterm-kitty"`.
 - [snacks.image](https://github.com/folke/snacks.nvim/blob/main/docs/image.md) -
   works, you need to set the environment variable `SNACKS_KITTY=1`.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ features.
   tmux!
 - [yazi](https://github.com/sxyazi/yazi) - works if you run it as
   `TERM="xterm-kitty" yazi`.
-- [mov-cli](https://github.com/mov-cli/mov-cli) - I had to explicitely set
+- [mov-cli](https://github.com/mov-cli/mov-cli) - I had to explicitly set
   `TERM="xterm-kitty"`.
 - [snacks.image](https://github.com/folke/snacks.nvim/blob/main/docs/image.md) -
   works, you need to set the environment variable `SNACKS_KITTY=1`.


### PR DESCRIPTION
I compiled the st-graphics and run `mov-cli`. it only worked after setting `TERM=xterm-kitty`
<img width="1043" height="1034" alt="image" src="https://github.com/user-attachments/assets/7283f3b7-ab9f-4c97-934d-cd46a0477b8c" />
